### PR TITLE
Update modbus.go to close the TCP connection after scraping is complete.

### DIFF
--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -68,6 +68,9 @@ func (e *Exporter) Scrape(targetAddress string, subTarget byte, moduleName strin
 
 	// TODO: Should we reuse this?
 	c := modbus.NewClient(handler)
+	
+	// Close tcp connection.
+	defer handler.Close()
 
 	metrics, err := scrapeMetrics(module.Metrics, c)
 	if err != nil {


### PR DESCRIPTION
Modus devices have a limited number of TCP connections.
I found after scraping does not close the connection