### PR TITLE
[WIP] Add 64 bits support and Endianness

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,8 @@ const (
 	ModbusFloat32 ModbusDataType = "float32"
 	ModbusInt16   ModbusDataType = "int16"
 	ModbusUInt16  ModbusDataType = "uint16"
+	ModbusInt32   ModbusDataType = "int32"
+	ModbusUInt32  ModbusDataType = "uint32"
 	ModbusBool    ModbusDataType = "bool"
 )
 
@@ -222,7 +224,7 @@ func (d *MetricDef) validate() error {
 			return fmt.Errorf("invalid endianness definition %v: %v", d.Name, err)
 		}
 	} else {
-		d.Endianness = "big"
+		d.Endianness = EndiannessBigEndian
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,9 @@ func (t *ModbusDataType) validate() error {
 		}
 	}
 
-	return fmt.Errorf("expected one of the following data types %v but got '%v'", possibleModbusDataTypes, *t)
+	return fmt.Errorf("expected one of the following data types %v but got '%v'",
+		possibleModbusDataTypes,
+		*t)
 }
 
 const (
@@ -109,6 +111,39 @@ const (
 	ModbusInt16   ModbusDataType = "int16"
 	ModbusUInt16  ModbusDataType = "uint16"
 	ModbusBool    ModbusDataType = "bool"
+)
+
+// EndiannessType is an Enum, representing the possible endianness types a register
+// value can have.
+type EndiannessType string
+
+func (endianness *EndiannessType) validate() error {
+	possibleEndiannessTypes := []EndiannessType{
+		EndiannessBigEndian,
+		EndiannessLittleEndian,
+		EndiannessMixedEndian,
+		EndiannessYolo,
+	}
+
+	for _, possibleEndianness := range possibleEndiannessTypes {
+		if *endianness == possibleEndianness {
+			return nil
+		}
+	}
+	return fmt.Errorf("expected one of the following endianness types %v but got '%v'",
+		possibleEndiannessTypes,
+		*endianness)
+}
+
+const (
+	// EndiannessBigEndian (1 2 3 4)
+	EndiannessBigEndian EndiannessType = "big"
+	// EndiannessLittleEndian (4 3 2 1)
+	EndiannessLittleEndian EndiannessType = "little"
+	// EndiannessMixedEndian (2 1 4 3)
+	EndiannessMixedEndian EndiannessType = "mixed"
+	// EndiannessYolo (3 4 1 2)
+	EndiannessYolo EndiannessType = "yolo"
 )
 
 // MetricType specifies the Prometheus metric type, see
@@ -131,7 +166,9 @@ func (t *MetricType) validate() error {
 		}
 	}
 
-	return fmt.Errorf("expected one of the following metric types %v but got '%v'", possibleMetricTypes, *t)
+	return fmt.Errorf("expected one of the following metric types %v but got '%v'",
+		possibleMetricTypes,
+		*t)
 }
 
 const (
@@ -155,6 +192,8 @@ type MetricDef struct {
 
 	DataType ModbusDataType `yaml:"dataType"`
 
+	Endianness EndiannessType `yaml:"endianness,omitempty"`
+
 	// Bit offset within the input register to parse. Only valid for boolean data
 	// type. The two bytes of a register are interpreted in network order (big
 	// endianness). Boolean is determined via `register&(1<<offset)>0`.
@@ -176,6 +215,12 @@ func (d *MetricDef) validate() error {
 	// TODO: Does it have to be used with bools though? Or should there be a default?
 	if d.BitOffset != nil && d.DataType != ModbusBool {
 		return fmt.Errorf("bitPosition can only be used with boolean data type")
+	}
+
+	if d.Endianness != "" {
+		if err := d.Endianness.validate(); err != nil {
+			return fmt.Errorf("invalid endianness definition %v: %v", d.Name, err)
+		}
 	}
 
 	return nil
@@ -215,7 +260,9 @@ func (t *ModbusProtocol) validate() error {
 		}
 	}
 
-	return fmt.Errorf("expected one of the following protocols %v but got '%v'", possibleProtocols, *t)
+	return fmt.Errorf("expected one of the following protocols %v but got '%v'",
+		possibleProtocols,
+		*t)
 }
 
 // Validate tries to find inconsistencies in the parameters of a module.

--- a/config/config.go
+++ b/config/config.go
@@ -83,11 +83,16 @@ type ModbusDataType string
 
 func (t *ModbusDataType) validate() error {
 	possibleModbusDataTypes := []ModbusDataType{
-		ModbusFloat16,
-		ModbusFloat32,
+		ModbusBool,
 		ModbusInt16,
 		ModbusUInt16,
-		ModbusBool,
+		ModbusFloat16,
+		ModbusInt32,
+		ModbusUInt32,
+		ModbusFloat32,
+		ModbusInt64,
+		ModbusUInt64,
+		ModbusFloat64,
 	}
 
 	if t == nil {
@@ -106,13 +111,16 @@ func (t *ModbusDataType) validate() error {
 }
 
 const (
+	ModbusBool    ModbusDataType = "bool"
 	ModbusFloat16 ModbusDataType = "float16"
-	ModbusFloat32 ModbusDataType = "float32"
 	ModbusInt16   ModbusDataType = "int16"
 	ModbusUInt16  ModbusDataType = "uint16"
 	ModbusInt32   ModbusDataType = "int32"
 	ModbusUInt32  ModbusDataType = "uint32"
-	ModbusBool    ModbusDataType = "bool"
+	ModbusFloat32 ModbusDataType = "float32"
+	ModbusInt64   ModbusDataType = "int64"
+	ModbusUInt64  ModbusDataType = "uint64"
+	ModbusFloat64 ModbusDataType = "float64"
 )
 
 // EndiannessType is an Enum, representing the possible endianness types a register

--- a/config/config.go
+++ b/config/config.go
@@ -221,6 +221,8 @@ func (d *MetricDef) validate() error {
 		if err := d.Endianness.validate(); err != nil {
 			return fmt.Errorf("invalid endianness definition %v: %v", d.Name, err)
 		}
+	} else {
+		d.Endianness = "big"
 	}
 
 	return nil

--- a/modbus.yml
+++ b/modbus.yml
@@ -10,10 +10,14 @@ modules:
         help: "represents the overall power consumption by phase"
         # Labels to be added to the time series.
         labels:
-                phase: "1"
-        # Modbus address.
+          phase: "1"
+        # Register address.
         address: 30022
+        # Datatypes allowed: bool, int16, uint16, float16, float32
         dataType: int16
+        # Endianities allowed: little, big, mixed, yolo 
+        # Optional. If not defined: big_endian.
+        endianity: big
         # Prometheus metric type: https://prometheus.io/docs/concepts/metric_types/.
         metricType: counter
 

--- a/modbus.yml
+++ b/modbus.yml
@@ -15,9 +15,9 @@ modules:
         address: 30022
         # Datatypes allowed: bool, int16, uint16, float16, float32
         dataType: int16
-        # Endianities allowed: little, big, mixed, yolo 
-        # Optional. If not defined: big_endian.
-        endianity: big
+        # Endianness allowed: big, little, mixed, yolo 
+        # Optional. If not defined: big.
+        endianness: big
         # Prometheus metric type: https://prometheus.io/docs/concepts/metric_types/.
         metricType: counter
 

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -264,16 +264,28 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 			if len(rawData) < 2 {
 				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
 			}
-			i := binary.BigEndian.Uint16(rawData)
-			return float64(int16(i)), nil
+			var data uint16
+			switch d.Endianness {
+			case config.EndiannessLittleEndian:
+				data = binary.LittleEndian.Uint16(rawData)
+			default:
+				data = binary.BigEndian.Uint16(rawData)
+			}
+			return float64(int16(data)), nil
 		}
 	case config.ModbusUInt16:
 		{
 			if len(rawData) < 2 {
 				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
 			}
-			i := binary.BigEndian.Uint16(rawData)
-			return float64(i), nil
+			var data uint16
+			switch d.Endianness {
+			case config.EndiannessLittleEndian:
+				data = binary.LittleEndian.Uint16(rawData)
+			default:
+				data = binary.BigEndian.Uint16(rawData)
+			}
+			return float64(data), nil
 		}
 	case config.ModbusBool:
 		{

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -41,6 +41,7 @@ func NewExporter(config config.Config) *Exporter {
 	return &Exporter{config}
 }
 
+// GetConfig loads the config file
 func (e *Exporter) GetConfig() *config.Config {
 	return &e.config
 }
@@ -261,64 +262,6 @@ func (e *InsufficientRegistersError) Error() string {
 // TODO: Handle Endianness.
 func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 	switch d.DataType {
-	case config.ModbusFloat16:
-		if len(rawData) < 2 {
-			return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
-		}
-		panic("implement")
-	case config.ModbusFloat32:
-		if len(rawData) < 4 {
-			return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 2, got %v", len(rawData))}
-		}
-		return float64(math.Float32frombits(binary.BigEndian.Uint32(rawData[:4]))), nil
-	case config.ModbusInt16:
-		{
-			if len(rawData) < 2 {
-				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
-			}
-			rawDataWithEndianness, err := convertEndianness16b(d.Endianness, rawData)
-			if err != nil {
-				return float64(0), err
-			}
-			data := binary.BigEndian.Uint16(rawDataWithEndianness)
-			return float64(int16(data)), nil
-		}
-	case config.ModbusUInt16:
-		{
-			if len(rawData) < 2 {
-				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
-			}
-			rawDataWithEndianness, err := convertEndianness16b(d.Endianness, rawData)
-			if err != nil {
-				return float64(0), err
-			}
-			data := binary.BigEndian.Uint16(rawDataWithEndianness)
-			return float64(data), nil
-		}
-	case config.ModbusInt32:
-		{
-			if len(rawData) < 4 {
-				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 2, got %v", len(rawData))}
-			}
-			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
-			if err != nil {
-				return float64(0), err
-			}
-			data := binary.BigEndian.Uint32(rawDataWithEndianness)
-			return float64(int32(data)), nil
-		}
-	case config.ModbusUInt32:
-		{
-			if len(rawData) < 4 {
-				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 2, got %v", len(rawData))}
-			}
-			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
-			if err != nil {
-				return float64(0), err
-			}
-			data := binary.BigEndian.Uint32(rawDataWithEndianness)
-			return float64(data), nil
-		}
 	case config.ModbusBool:
 		{
 			// TODO: Maybe we don't need two registers for bool.
@@ -337,8 +280,113 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 			}
 			return float64(0), nil
 		}
+	case config.ModbusFloat16:
+		{
+			if len(rawData) != 2 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 1, got %v", len(rawData))}
+			}
+			panic("implement")
+		}
+	case config.ModbusInt16:
+		{
+			if len(rawData) != 2 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 1, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness16b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint16(rawDataWithEndianness)
+			return float64(int16(data)), nil
+		}
+	case config.ModbusUInt16:
+		{
+			if len(rawData) != 2 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 1, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness16b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint16(rawDataWithEndianness)
+			return float64(data), nil
+		}
+	case config.ModbusInt32:
+		{
+			if len(rawData) != 4 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 2, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint32(rawDataWithEndianness)
+			return float64(int32(data)), nil
+		}
+	case config.ModbusUInt32:
+		{
+			if len(rawData) != 4 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 2, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint32(rawDataWithEndianness)
+			return float64(data), nil
+		}
+	case config.ModbusFloat32:
+		{
+			if len(rawData) != 4 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 2, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint32(rawDataWithEndianness)
+			return float64(math.Float32frombits(data)), nil
+		}
+	case config.ModbusInt64:
+		{
+			if len(rawData) != 8 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 4, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness64b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint64(rawDataWithEndianness)
+			return float64(int64(data)), nil
+		}
+	case config.ModbusUInt64:
+		{
+			if len(rawData) != 8 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 4, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness64b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint64(rawDataWithEndianness)
+			return float64(data), nil
+		}
+	case config.ModbusFloat64:
+		{
+			if len(rawData) != 8 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected 4, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness64b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint64(rawDataWithEndianness)
+			return math.Float64frombits(data), nil
+		}
 	default:
-		return 0, fmt.Errorf("unknown modbus data type")
+		{
+			return 0, fmt.Errorf("unknown modbus data type")
+		}
 	}
 }
 
@@ -365,7 +413,8 @@ func convertEndianness16b(rawEndianness config.EndiannessType, rawData []byte) (
 // Converts an array of 32 bits from an endianness to the default big Endian
 func convertEndianness32b(rawEndianness config.EndiannessType, rawData []byte) ([]byte, error) {
 	if len(rawData) != 4 {
-		return []byte{uint8(0), uint8(0), uint8(0), uint8(0)}, fmt.Errorf("expected 4 bytes, got %v", len(rawData))
+		return []byte{uint8(0), uint8(0), uint8(0), uint8(0)},
+			fmt.Errorf("expected 4 bytes, got %v", len(rawData))
 	}
 	var data []byte
 	switch rawEndianness {
@@ -394,6 +443,59 @@ func convertEndianness32b(rawEndianness config.EndiannessType, rawData []byte) (
 			rawData[1],
 			rawData[2],
 			rawData[3]}
+	}
+	return data, nil
+}
+
+// Converts an array of 64 bits from an endianness to the default big Endian
+func convertEndianness64b(rawEndianness config.EndiannessType, rawData []byte) ([]byte, error) {
+	if len(rawData) != 8 {
+		return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0)},
+			fmt.Errorf("expected 8 bytes, got %v", len(rawData))
+	}
+	var data []byte
+	switch rawEndianness {
+	case config.EndiannessLittleEndian:
+		data = []byte{
+			rawData[7],
+			rawData[6],
+			rawData[5],
+			rawData[4],
+			rawData[3],
+			rawData[2],
+			rawData[1],
+			rawData[0]}
+	case config.EndiannessMixedEndian:
+		data = []byte{
+			rawData[1],
+			rawData[0],
+			rawData[3],
+			rawData[2],
+			rawData[5],
+			rawData[4],
+			rawData[7],
+			rawData[6]}
+	case config.EndiannessYolo:
+		data = []byte{
+			rawData[6],
+			rawData[7],
+			rawData[4],
+			rawData[5],
+			rawData[2],
+			rawData[3],
+			rawData[0],
+			rawData[1]}
+	// default: BigEndian
+	default:
+		data = []byte{
+			rawData[0],
+			rawData[1],
+			rawData[2],
+			rawData[3],
+			rawData[4],
+			rawData[5],
+			rawData[6],
+			rawData[7]}
 	}
 	return data, nil
 }

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -210,11 +210,23 @@ type modbusFunc func(address, quantity uint16) ([]byte, error)
 // scrapeMetric returns the list of values from a target
 func scrapeMetric(definition config.MetricDef, f modbusFunc) (metric, error) {
 	// For now we are not caching any results, thus we can request the
-	// minimum necessary amount of registers per request. Our biggest data type
-	// is float32, thereby 2 registers are enough. For future reference, the
-	// maximum for digital in/output is 2000 registers, the maximum for analog
-	// in/output is 125.
-	div := uint16(2)
+	// minimum necessary amount of registers per request dependint in the dataType.
+	// For future reference, the maximum for digital in/output is 2000 registers,
+	// the maximum for analog in/output is 125.
+	var div uint16
+	switch definition.DataType {
+	case config.ModbusFloat16,
+		config.ModbusInt16,
+		config.ModbusUInt16:
+		div = uint16(1)
+	case config.ModbusFloat32,
+		config.ModbusInt32,
+		config.ModbusUInt32,
+		config.ModbusBool:
+		div = uint16(2)
+	default:
+		div = uint16(4)
+	}
 
 	// TODO: We could cache the results to not repeat overlapping ones.
 	// Modulo 10000 as the first digit identifies the modbus function code
@@ -264,13 +276,11 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 			if len(rawData) < 2 {
 				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
 			}
-			var data uint16
-			switch d.Endianness {
-			case config.EndiannessLittleEndian:
-				data = binary.LittleEndian.Uint16(rawData)
-			default:
-				data = binary.BigEndian.Uint16(rawData)
+			rawDataWithEndianness, err := convertEndianness16b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
 			}
+			data := binary.BigEndian.Uint16(rawDataWithEndianness)
 			return float64(int16(data)), nil
 		}
 	case config.ModbusUInt16:
@@ -278,13 +288,35 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 			if len(rawData) < 2 {
 				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 1, got %v", len(rawData))}
 			}
-			var data uint16
-			switch d.Endianness {
-			case config.EndiannessLittleEndian:
-				data = binary.LittleEndian.Uint16(rawData)
-			default:
-				data = binary.BigEndian.Uint16(rawData)
+			rawDataWithEndianness, err := convertEndianness16b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
 			}
+			data := binary.BigEndian.Uint16(rawDataWithEndianness)
+			return float64(data), nil
+		}
+	case config.ModbusInt32:
+		{
+			if len(rawData) < 4 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 2, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint32(rawDataWithEndianness)
+			return float64(int32(data)), nil
+		}
+	case config.ModbusUInt32:
+		{
+			if len(rawData) < 4 {
+				return float64(0), &InsufficientRegistersError{fmt.Sprintf("expected at least 2, got %v", len(rawData))}
+			}
+			rawDataWithEndianness, err := convertEndianness32b(d.Endianness, rawData)
+			if err != nil {
+				return float64(0), err
+			}
+			data := binary.BigEndian.Uint32(rawDataWithEndianness)
 			return float64(data), nil
 		}
 	case config.ModbusBool:
@@ -308,4 +340,60 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 	default:
 		return 0, fmt.Errorf("unknown modbus data type")
 	}
+}
+
+// Converts an array of 16 bits from an endianness to the default big Endian
+func convertEndianness16b(rawEndianness config.EndiannessType, rawData []byte) ([]byte, error) {
+	if len(rawData) != 2 {
+		return []byte{uint8(0), uint8(0)}, fmt.Errorf("expected 2 bytes, got %v", len(rawData))
+	}
+	var data []byte
+	switch rawEndianness {
+	case config.EndiannessLittleEndian:
+		data = []byte{
+			rawData[1],
+			rawData[0]}
+	// default: BigEndian
+	default:
+		data = []byte{
+			rawData[0],
+			rawData[1]}
+	}
+	return data, nil
+}
+
+// Converts an array of 32 bits from an endianness to the default big Endian
+func convertEndianness32b(rawEndianness config.EndiannessType, rawData []byte) ([]byte, error) {
+	if len(rawData) != 4 {
+		return []byte{uint8(0), uint8(0), uint8(0), uint8(0)}, fmt.Errorf("expected 4 bytes, got %v", len(rawData))
+	}
+	var data []byte
+	switch rawEndianness {
+	case config.EndiannessLittleEndian:
+		data = []byte{
+			rawData[3],
+			rawData[2],
+			rawData[1],
+			rawData[0]}
+	case config.EndiannessMixedEndian:
+		data = []byte{
+			rawData[1],
+			rawData[0],
+			rawData[3],
+			rawData[2]}
+	case config.EndiannessYolo:
+		data = []byte{
+			rawData[2],
+			rawData[3],
+			rawData[0],
+			rawData[1]}
+	// default: BigEndian
+	default:
+		data = []byte{
+			rawData[0],
+			rawData[1],
+			rawData[2],
+			rawData[3]}
+	}
+	return data, nil
 }

--- a/modbus/modbus_test.go
+++ b/modbus/modbus_test.go
@@ -117,6 +117,82 @@ func TestParseModbusData(t *testing.T) {
 			},
 			expectedValue: 1,
 		},
+		{
+			name: "int16, default endian (big endian)",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType: config.ModbusInt16,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int16, Big endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt16,
+					Endianness: config.EndiannessBigEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int16, Little endian",
+			input: func() []byte {
+				return []byte{uint8(1), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt16,
+					Endianness: config.EndiannessLittleEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint16, default endian (big endian)",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType: config.ModbusUInt16,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint16, Big endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt16,
+					Endianness: config.EndiannessBigEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint16, Little endian",
+			input: func() []byte {
+				return []byte{uint8(1), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt16,
+					Endianness: config.EndiannessLittleEndian,
+				}
+			},
+			expectedValue: 1,
+		},
 	}
 
 	for _, loopTest := range tests {

--- a/modbus/modbus_test.go
+++ b/modbus/modbus_test.go
@@ -194,6 +194,70 @@ func TestParseModbusData(t *testing.T) {
 			expectedValue: 1,
 		},
 		{
+			name: "int32, default endian (big endian)",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType: config.ModbusInt32,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Big endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessBigEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Little endian",
+			input: func() []byte {
+				return []byte{uint8(1), uint8(0), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessLittleEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Mixed endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(1), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessMixedEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Yolo endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessYolo,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
 			name: "uint32, default endian (big endian)",
 			input: func() []byte {
 				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
@@ -258,64 +322,128 @@ func TestParseModbusData(t *testing.T) {
 			expectedValue: 1,
 		},
 		{
-			name: "int32, default endian (big endian)",
+			name: "int64, default endian (big endian)",
 			input: func() []byte {
-				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(1)}
 			},
 			metricDef: func() *config.MetricDef {
 				return &config.MetricDef{
-					DataType: config.ModbusInt32,
+					DataType: config.ModbusInt64,
 				}
 			},
 			expectedValue: 1,
 		},
 		{
-			name: "int32, Big endian",
+			name: "int64, Big endian",
 			input: func() []byte {
-				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(1)}
 			},
 			metricDef: func() *config.MetricDef {
 				return &config.MetricDef{
-					DataType:   config.ModbusInt32,
+					DataType:   config.ModbusInt64,
 					Endianness: config.EndiannessBigEndian,
 				}
 			},
 			expectedValue: 1,
 		},
 		{
-			name: "int32, Little endian",
+			name: "int64, Little endian",
 			input: func() []byte {
-				return []byte{uint8(1), uint8(0), uint8(0), uint8(0)}
+				return []byte{uint8(1), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0)}
 			},
 			metricDef: func() *config.MetricDef {
 				return &config.MetricDef{
-					DataType:   config.ModbusInt32,
+					DataType:   config.ModbusInt64,
 					Endianness: config.EndiannessLittleEndian,
 				}
 			},
 			expectedValue: 1,
 		},
 		{
-			name: "int32, Mixed endian",
+			name: "int64, Mixed endian",
 			input: func() []byte {
-				return []byte{uint8(0), uint8(0), uint8(1), uint8(0)}
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(1), uint8(0)}
 			},
 			metricDef: func() *config.MetricDef {
 				return &config.MetricDef{
-					DataType:   config.ModbusInt32,
+					DataType:   config.ModbusInt64,
 					Endianness: config.EndiannessMixedEndian,
 				}
 			},
 			expectedValue: 1,
 		},
 		{
-			name: "int32, Yolo endian",
+			name: "int64, Yolo endian",
 			input: func() []byte {
-				return []byte{uint8(0), uint8(1), uint8(0), uint8(0)}
+				return []byte{uint8(0), uint8(1), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0)}
 			},
 			metricDef: func() *config.MetricDef {
 				return &config.MetricDef{
-					DataType:   config.ModbusInt32,
+					DataType:   config.ModbusInt64,
+					Endianness: config.EndiannessYolo,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint64, default endian (big endian)",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType: config.ModbusUInt64,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint64, Big endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt64,
+					Endianness: config.EndiannessBigEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint64, Little endian",
+			input: func() []byte {
+				return []byte{uint8(1), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt64,
+					Endianness: config.EndiannessLittleEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint64, Mixed endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(1), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt64,
+					Endianness: config.EndiannessMixedEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint64, Yolo endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt64,
 					Endianness: config.EndiannessYolo,
 				}
 			},

--- a/modbus/modbus_test.go
+++ b/modbus/modbus_test.go
@@ -193,6 +193,134 @@ func TestParseModbusData(t *testing.T) {
 			},
 			expectedValue: 1,
 		},
+		{
+			name: "uint32, default endian (big endian)",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType: config.ModbusUInt32,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint32, Big endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt32,
+					Endianness: config.EndiannessBigEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint32, Little endian",
+			input: func() []byte {
+				return []byte{uint8(1), uint8(0), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt32,
+					Endianness: config.EndiannessLittleEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint32, Mixed endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(1), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt32,
+					Endianness: config.EndiannessMixedEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "uint32, Yolo endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusUInt32,
+					Endianness: config.EndiannessYolo,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, default endian (big endian)",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType: config.ModbusInt32,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Big endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(0), uint8(1)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessBigEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Little endian",
+			input: func() []byte {
+				return []byte{uint8(1), uint8(0), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessLittleEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Mixed endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(0), uint8(1), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessMixedEndian,
+				}
+			},
+			expectedValue: 1,
+		},
+		{
+			name: "int32, Yolo endian",
+			input: func() []byte {
+				return []byte{uint8(0), uint8(1), uint8(0), uint8(0)}
+			},
+			metricDef: func() *config.MetricDef {
+				return &config.MetricDef{
+					DataType:   config.ModbusInt32,
+					Endianness: config.EndiannessYolo,
+				}
+			},
+			expectedValue: 1,
+		},
 	}
 
 	for _, loopTest := range tests {


### PR DESCRIPTION
This PR implements #3 

Adds support for endianness:
- Big Endian: 1 2 3 4
- Little Endian: 4 3 2 1
- Mixed Endian: 2 1 3 4 
- Yolo Endian: 3 4 1 2

Adds support for 32 and 64 bits new variables: 
- int32
- uint32
- in64
- uint64
- float64

Added control of the bytes scraped according to the data type.
Added control of the bytes of the raw data before parsing.
Added unit tests.