### PR TITLE
Add counter for errors and change the entry point of exporter metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ Usage of ./modbus_exporter:
   -modbus-listen-address string
     	The address to listen on for HTTP requests exposing modbus metrics. (default ":9602")
   -telemetry-listen-address string
-    	The address to listen on for HTTP requests exposing telemetry metrics about the exporter itself. (default ":9011")
+    	The address to listen on for HTTP requests exposing telemetry metrics about the exporter itself. (default ":9602")
 ```
+Visit http://localhost:9602/modbus?target=1.2.3.4 where 1.2.3.4 is the IP of the modbus IP device to get metrics from. You can also specify a module and a sub_target parameter, to choose which module and subtarget to use from the config file. 
 
+Visit http://localhost:9602/metrics to get the metrics of the exporter itself.
 
 ## Configuration File
 

--- a/modbus.yml
+++ b/modbus.yml
@@ -13,7 +13,8 @@ modules:
           phase: "1"
         # Register address.
         address: 30022
-        # Datatypes allowed: bool, int16, uint16, float16, float32
+        # Datatypes allowed: bool, int16, uint16, int32, uint32, 
+        # int64, uint64, float16 (not implemented), float32, float64
         dataType: int16
         # Endianness allowed: big, little, mixed, yolo 
         # Optional. If not defined: big.

--- a/modbus_exporter.go
+++ b/modbus_exporter.go
@@ -37,11 +37,11 @@ import (
 type ModbusRequestStatusType string
 
 const (
-	// ModbusRequestStatusOK sucessful
+	// ModbusRequestStatusOK successful
 	ModbusRequestStatusOK ModbusRequestStatusType = "OK"
 	// ModbusRequestStatusErrorSock error opening socket connection
 	ModbusRequestStatusErrorSock ModbusRequestStatusType = "ERROR_SOCKET"
-	// ModbusRequestStatusErrorTimeout connection stablished but no response from modbus device
+	// ModbusRequestStatusErrorTimeout connection established but no response from modbus device
 	ModbusRequestStatusErrorTimeout ModbusRequestStatusType = "ERROR_TIMEOUT"
 	// ModbusRequestStatusErrorParsingValue error parsing value received
 	ModbusRequestStatusErrorParsingValue ModbusRequestStatusType = "ERROR_PARSING_VALUE"


### PR DESCRIPTION
This PR implements #4 and its comments on:
- Add counter for the different possible errors (connection, timeout...)
- Moving the exporter metrics from :0911/metrics to :9602/metrics
- Moving the target metrics from :9602/metrics to :9602/modbus?target=1.2.3.4&module=module_name&sub_target=subtarget_number

Documentation of the new metrics of the exporter:
- Added counter modbus_requests_total with labels for:
   - target
   - request status

- Added counter modbus_request_duration_seconds_total with labels for:
    - target

- Added possible requests status:
   - OK:  successful
   - ERROR_SOCKET: error opening socket connection
   - ERROR_TIMEOUT: connection established but no response from modbus device
   - ERROR_PARSING_VALUE: error parsing value received

Error status start with "ERROR" so it is easy to filter in promQL.