### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang as builder
+ADD . /go/modbus_exporter
+WORKDIR /go/modbus_exporter
+RUN make build
+
+FROM ubuntu:latest
+WORKDIR /app
+COPY --from=builder /go/modbus_exporter/modbus_exporter .
+COPY --from=builder /go/modbus_exporter/modbus.yml .
+ENTRYPOINT ["./modbus_exporter"]
+EXPOSE 9602
+EXPOSE 9011


### PR DESCRIPTION
With this Dockerfile you should be able to create an auto build on docker hub and offer anyone a prebuilt container.  
I've already set up https://hub.docker.com/repository/docker/momorientes/modbus_exporter/general for now, but would delete it in favor of an official version.
  
Please be gentle on my Docker skills, they're mediocre at best.