### PR TITLE
Add support for non-standart addresses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,7 @@ type Module struct {
 
 // RegisterAddr specifies the register in the possible output of _digital
 // output_, _digital input, _ananlog input, _analog output_.
-type RegisterAddr uint16
+type RegisterAddr uint32
 
 // ModbusDataType is an Enum, representing the possible data types a register
 // value can be interpreted as.

--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,9 @@ type MetricDef struct {
 	BitOffset *int `yaml:"bitOffset,omitempty"`
 
 	MetricType MetricType `yaml:"metricType"`
+
+	// Scaling factor
+	Factor *float64 `yaml:"factor,omitempty"`
 }
 
 // Validate semantically validates the given metric definition.
@@ -233,6 +236,14 @@ func (d *MetricDef) validate() error {
 		}
 	} else {
 		d.Endianness = EndiannessBigEndian
+	}
+
+	if d.Factor != nil && d.DataType == ModbusBool {
+		return fmt.Errorf("factor cannot be used with boolean data type")
+	}
+
+	if d.Factor != nil && *d.Factor == 0.0 {
+		return fmt.Errorf("factor cannot be 0")
 	}
 
 	return nil

--- a/modbus.yml
+++ b/modbus.yml
@@ -12,7 +12,7 @@ modules:
         labels:
           phase: "1"
         # Register address.
-        address: 30022
+        address: 300022
         # Datatypes allowed: bool, int16, uint16, float16, float32
         dataType: int16
         # Endianness allowed: big, little, mixed, yolo 
@@ -27,14 +27,14 @@ modules:
 
       - name: "some_gauge"
         help: "some help for some gauge"
-        address: 30023
+        address: 300023
         dataType: int16
         metricType: gauge
         factor: 2
 
       - name: "coil"
         help: "some help for some coil"
-        address: 10024
+        address: 100024
         dataType: bool
         bitOffset: 0
         metricType: gauge

--- a/modbus.yml
+++ b/modbus.yml
@@ -20,12 +20,17 @@ modules:
         endianness: big
         # Prometheus metric type: https://prometheus.io/docs/concepts/metric_types/.
         metricType: counter
+        # Factor can be specified to represent metric value.
+        # Examples: 1, 2, 1.543 etc
+        # Optional.
+        factor: 3.1415926535
 
       - name: "some_gauge"
         help: "some help for some gauge"
         address: 30023
         dataType: int16
         metricType: gauge
+        factor: 2
 
       - name: "coil"
         help: "some help for some coil"

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -296,7 +296,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint16(rawDataWithEndianness)
-			return float64(int16(data)), nil
+			return scaleValue(d.Factor, float64(int16(data))), nil
 		}
 	case config.ModbusUInt16:
 		{
@@ -308,7 +308,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint16(rawDataWithEndianness)
-			return float64(data), nil
+			return scaleValue(d.Factor, float64(data)), nil
 		}
 	case config.ModbusInt32:
 		{
@@ -320,7 +320,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint32(rawDataWithEndianness)
-			return float64(int32(data)), nil
+			return scaleValue(d.Factor, float64(int32(data))), nil
 		}
 	case config.ModbusUInt32:
 		{
@@ -332,7 +332,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint32(rawDataWithEndianness)
-			return float64(data), nil
+			return scaleValue(d.Factor, float64(data)), nil
 		}
 	case config.ModbusFloat32:
 		{
@@ -344,7 +344,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint32(rawDataWithEndianness)
-			return float64(math.Float32frombits(data)), nil
+			return scaleValue(d.Factor, float64(math.Float32frombits(data))), nil
 		}
 	case config.ModbusInt64:
 		{
@@ -356,7 +356,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint64(rawDataWithEndianness)
-			return float64(int64(data)), nil
+			return scaleValue(d.Factor, float64(int64(data))), nil
 		}
 	case config.ModbusUInt64:
 		{
@@ -368,7 +368,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint64(rawDataWithEndianness)
-			return float64(data), nil
+			return scaleValue(d.Factor, float64(data)), nil
 		}
 	case config.ModbusFloat64:
 		{
@@ -380,13 +380,21 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 				return float64(0), err
 			}
 			data := binary.BigEndian.Uint64(rawDataWithEndianness)
-			return math.Float64frombits(data), nil
+			return scaleValue(d.Factor, math.Float64frombits(data)), nil
 		}
 	default:
 		{
 			return 0, fmt.Errorf("unknown modbus data type")
 		}
 	}
+}
+
+// Scales value by factor
+func scaleValue(f *float64, d float64) float64 {
+	if f == nil {
+		return d
+	}
+	return (d * float64(*f))
 }
 
 // Converts an array of 16 bits from an endianness to the default big Endian

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -179,7 +179,7 @@ func scrapeMetrics(definitions []config.MetricDef, c modbus.Client) ([]metric, e
 	for _, definition := range definitions {
 		var f modbusFunc
 
-		switch definition.Address / 10000 {
+		switch definition.Address / 100000 {
 		case 1:
 			f = c.ReadCoils
 		case 2:
@@ -235,7 +235,7 @@ func scrapeMetric(definition config.MetricDef, f modbusFunc) (metric, error) {
 	// TODO: We could cache the results to not repeat overlapping ones.
 	// Modulo 10000 as the first digit identifies the modbus function code
 	// (1-4).
-	modBytes, err := f(uint16(definition.Address%10000), div)
+	modBytes, err := f(uint16(definition.Address%100000), div)
 	if err != nil {
 		return metric{}, err
 	}


### PR DESCRIPTION
I don't know why is such limitation has place, but if it has special purpose let me know, @RichiH 🤨
Seems like easy task and some people asked about support for non-standart addresses - #11, #12, #14 (it is 1/3 of all open issues😂)
I've tested it with a fake module and with a real modbus-device (work fine, implemented scaling working too)

P.S. Sorry for messy pull-requests, I'll try to avoid that in the future 🙄