### PR TITLE
Cleanup uncessary metrics

### DIFF
--- a/modbus_exporter.go
+++ b/modbus_exporter.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -31,25 +30,6 @@ import (
 
 	"github.com/lupoDharkael/modbus_exporter/config"
 	"github.com/lupoDharkael/modbus_exporter/modbus"
-)
-
-// ModbusRequestStatusType possible status of the modbus request
-type ModbusRequestStatusType string
-
-const (
-	// ModbusRequestStatusOK successful
-	ModbusRequestStatusOK ModbusRequestStatusType = "OK"
-	// ModbusRequestStatusErrorSock error opening socket connection
-	ModbusRequestStatusErrorSock ModbusRequestStatusType = "ERROR_SOCKET"
-	// ModbusRequestStatusErrorTimeout connection established but no response from modbus device
-	ModbusRequestStatusErrorTimeout ModbusRequestStatusType = "ERROR_TIMEOUT"
-	// ModbusRequestStatusErrorParsingValue error parsing value received
-	ModbusRequestStatusErrorParsingValue ModbusRequestStatusType = "ERROR_PARSING_VALUE"
-)
-
-var (
-	modbusDurationCounterVec *prometheus.CounterVec
-	modbusRequestsCounterVec *prometheus.CounterVec
 )
 
 func main() {
@@ -65,18 +45,6 @@ func main() {
 	telemetryRegistry := prometheus.NewRegistry()
 	telemetryRegistry.MustRegister(prometheus.NewGoCollector())
 	telemetryRegistry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-
-	modbusDurationCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "modbus_request_duration_seconds_total",
-		Help: "Total duration of modbus successful requests by target in seconds",
-	}, []string{"target"})
-	telemetryRegistry.MustRegister(modbusDurationCounterVec)
-
-	modbusRequestsCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "modbus_requests_total",
-		Help: "Number of modbus request by status and target",
-	}, []string{"target", "status"})
-	telemetryRegistry.MustRegister(modbusRequestsCounterVec)
 
 	log.Infoln("Loading configuration file", *configFile)
 	config, err := config.LoadConfig(*configFile)
@@ -129,27 +97,22 @@ func scrapeHandler(e *modbus.Exporter, w http.ResponseWriter, r *http.Request) {
 
 	log.Infof("got scrape request for module '%v' target '%v' and sub_target '%v'", moduleName, target, subTarget)
 
-	start := time.Now()
 	gatherer, err := e.Scrape(target, byte(subTarget), moduleName)
-	duration := time.Since(start).Seconds()
 	if err != nil {
+		httpStatus := http.StatusInternalServerError
 		if strings.Contains(fmt.Sprintf("%v", err), "unable to connect with target") {
-			modbusRequestsCounterVec.WithLabelValues(target, string(ModbusRequestStatusErrorSock)).Inc()
+			httpStatus = http.StatusServiceUnavailable
 		} else if strings.Contains(fmt.Sprintf("%v", err), "i/o timeout") {
-			modbusRequestsCounterVec.WithLabelValues(target, string(ModbusRequestStatusErrorTimeout)).Inc()
-		} else {
-			modbusRequestsCounterVec.WithLabelValues(target, string(ModbusRequestStatusErrorParsingValue)).Inc()
+			httpStatus = http.StatusGatewayTimeout
 		}
 		http.Error(
 			w,
 			fmt.Sprintf("failed to scrape target '%v' with module '%v': %v", target, moduleName, err),
-			http.StatusInternalServerError,
+			httpStatus,
 		)
 		log.Error(err)
 		return
 	}
-	modbusDurationCounterVec.WithLabelValues(target).Add(duration)
-	modbusRequestsCounterVec.WithLabelValues(target, string(ModbusRequestStatusOK)).Inc()
 
 	promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}).ServeHTTP(w, r)
 }


### PR DESCRIPTION
Remove the modbus exporter meta-metrics that duplicate data from
the scrape information. In order to differentiate between different
failures, use http status codes instead.

Signed-off-by: Ben Kochie <superq@gmail.com>