### PR TITLE
Ignoremetrics: add feature to ignore Values returned by modbus device

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -213,6 +213,15 @@ type MetricDef struct {
 
 	// Scaling factor
 	Factor *float64 `yaml:"factor,omitempty"`
+
+	// Special return values with meaning
+	IgnoredValues []IgnoredValueDef `yaml:"ignoredValues,omitempty"`
+}
+
+// IgnoredValueDef defines an array of special values and the return error
+type IgnoredValueDef struct {
+	Value   *float64 `yaml:"value"`
+	Meaning string   `yaml:"meaning"`
 }
 
 // Validate semantically validates the given metric definition.

--- a/modbus.yml
+++ b/modbus.yml
@@ -42,3 +42,12 @@ modules:
         dataType: bool
         bitOffset: 0
         metricType: gauge
+
+      - name: "some_special_device_with_buggy_values"
+        help: "some help for some coil"
+        address: 301220
+        dataType: int16
+        metricType: counter
+        ignoredvalues:
+          4294934512: "Data pending, acquisition in progress"
+          4294934524: "The sensor is known but not accessible at the moment"

--- a/modbus.yml
+++ b/modbus.yml
@@ -48,6 +48,9 @@ modules:
         address: 301220
         dataType: int16
         metricType: counter
-        ignoredvalues:
-          4294934512: "Data pending, acquisition in progress"
-          4294934524: "The sensor is known but not accessible at the moment"
+        ignoredValues:
+        - value: 4294934512
+          meaning: Data pending, acquisition in progress
+        - value: 4294934513
+          meaning: Reserved
+

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -263,7 +263,23 @@ func scrapeMetric(definition config.MetricDef, f modbusFunc, modAddress uint64) 
 		return metric{}, err
 	}
 
+	// Check Value with special meaning from config.yml
+	for _, iv := range definition.IgnoredValues {
+		if v == *iv.Value {
+			return metric{}, &IgnoredValueMeaningError{fmt.Sprintf("value is %v - %s", *iv.Value, iv.Meaning)}
+		}
+	}
+
 	return metric{definition.Name, definition.Help, definition.Labels, v, definition.MetricType}, nil
+}
+
+// IgnoredValueMeaningError is returned whenever a value equals the ignoredValue defined in config.yaml
+type IgnoredValueMeaningError struct {
+	e string
+}
+
+func (e *IgnoredValueMeaningError) Error() string {
+	return fmt.Sprintf("ignored value returned as value: %v", e.e)
 }
 
 // InsufficientRegistersError is returned in Parse() whenever not enough


### PR DESCRIPTION
Devices like CMS700 from ABB send Error codes as Values which break monotonicity for counters.

Example:
Watt Hours should only be increasing in a normal rate. CMS 700 sends out 4.294.934.512 Wh  if the sensor has not yet returned data, which can result in sudden GWh consumtion within the scrape interval if you use a "increase()" on that metric.