### PR TITLE
README: mention that sub_module is a required parameter and target ne…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make build
 
 ## Getting Started
 
-The modbus exporter needs to be passed the *target* and *module* as parameters
+The modbus exporter needs to be passed *target* (including port), *module* and *sub_module* as parameters
 by Prometheus, this can be done with relabelling (see
 [prometheus.yml](prometheus.yml)).
 
@@ -64,7 +64,9 @@ Usage of ./modbus_exporter:
   -telemetry-listen-address string
     	The address to listen on for HTTP requests exposing telemetry metrics about the exporter itself. (default ":9602")
 ```
-Visit http://localhost:9602/modbus?target=1.2.3.4 where 1.2.3.4 is the IP of the modbus IP device to get metrics from. You can also specify a module and a sub_target parameter, to choose which module and subtarget to use from the config file.
+Visit http://localhost:9602/modbus?target=1.2.3.4:502&module=fake&sub_target=1 where 1.2.3.4:502 is the IP and port number of the modbus IP device to get metrics from,
+while module and sub_target parameters specify which module and subtarget to use from the config file.
+If your device doesn't use sub-targets you can usually just set it to 1.
 
 Visit http://localhost:9602/metrics to get the metrics of the exporter itself.
 

--- a/modbus.yml
+++ b/modbus.yml
@@ -17,6 +17,7 @@ modules:
         address: 300022
         # Datatypes allowed: bool, int16, int32, int64, uint16, uint32, uint64,
         #   float16, float32, float64
+        # One register holds 16 bits.
         dataType: int16
         # Endianness allowed: big, little, mixed, yolo
         # Optional. If not defined: big.


### PR DESCRIPTION
…eds to include the port (fixes: #28)

Also add a helpful hint to modbus.yml how to turn "two registers wide" into a datatype.

This is info that would have helped me a lot when starting to use modbus_exporter. I hope this PR can make it more visible.