### PR TITLE
Fix tests

### DIFF
--- a/modbus_exporter_test.go
+++ b/modbus_exporter_test.go
@@ -59,7 +59,7 @@ func TestScrapeHandler(t *testing.T) {
 			name: "module and target",
 			// The exporter won't be able to access the target,
 			// thus, validation should pass (no 400) but scrape should
-			// fail (500). One could stub the exporter itself.
+			// fail (503). One could stub the exporter itself.
 			code: http.StatusServiceUnavailable,
 			config: func() config.Config {
 				c := config.Config{}

--- a/modbus_exporter_test.go
+++ b/modbus_exporter_test.go
@@ -60,7 +60,7 @@ func TestScrapeHandler(t *testing.T) {
 			// The exporter won't be able to access the target,
 			// thus, validation should pass (no 400) but scrape should
 			// fail (500). One could stub the exporter itself.
-			code: http.StatusInternalServerError,
+			code: http.StatusServiceUnavailable,
 			config: func() config.Config {
 				c := config.Config{}
 				c.Modules = []config.Module{


### PR DESCRIPTION
The exporter specifically returns code 503 (`http.StatusServiceUnavailable`) when it can't connect, not 500.

https://github.com/RichiH/modbus_exporter/blob/ade432bf346ece4cdc42ccbce4c39123ba0c064f/modbus_exporter.go#L106-L107

cc @SuperQ 