### PR TITLE
helm chart for prometheus operator serviceMonitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Exporter-->Prometheus:temperature_a{module="VendorXY",sub_target="10"} 20 \ntemp
 make build
 ```
 
+## Installing using kubernetes helm charts
+Ideal way to install when using prometheus operator ServiceMonitors.    
+Prometheus stack helm for kubernetes can be installed from here: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack   
+A kubernetes installer using ansible that installs prometheus and grafana out of the box, can be found here: https://github.com/ReSearchITEng/kubeadm-playbook    
+
+Helm install command:
+```bash
+helm install modbus-exporter oci://docker.io/openenergyprojects/modbus-exporter --version 0.1.0 # -f customValues.yaml
+```
 
 ## Getting Started
 

--- a/charts/modbus-exporter/.bashrc
+++ b/charts/modbus-exporter/.bashrc
@@ -1,0 +1,1 @@
+export WINDOWS_IP=${WINDOWS_IP:-$(dig +short $(hostname -f))}

--- a/charts/modbus-exporter/.bashrc
+++ b/charts/modbus-exporter/.bashrc
@@ -1,1 +1,0 @@
-export WINDOWS_IP=${WINDOWS_IP:-$(dig +short $(hostname -f))}

--- a/charts/modbus-exporter/.helmignore
+++ b/charts/modbus-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/modbus-exporter/Chart.yaml
+++ b/charts/modbus-exporter/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: modbus-exporter
+description: A Helm chart for modbus-exporter
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.4.0"

--- a/charts/modbus-exporter/templates/NOTES.txt
+++ b/charts/modbus-exporter/templates/NOTES.txt
@@ -1,0 +1,2 @@
+1. Get the application URL by running these commands:
+GLHF

--- a/charts/modbus-exporter/templates/_helpers.tpl
+++ b/charts/modbus-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "modbus-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "modbus-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "modbus-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "modbus-exporter.labels" -}}
+helm.sh/chart: {{ include "modbus-exporter.chart" . }}
+{{ include "modbus-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "modbus-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "modbus-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "modbus-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "modbus-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/modbus-exporter/templates/configmap.yaml
+++ b/charts/modbus-exporter/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.configMapFile -}}
+{{- $fullName := include "modbus-exporter.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+data:
+  modbus.yml: |
+    modules:
+{{- toYaml .Values.modules | nindent 4 }}
+{{- end }}

--- a/charts/modbus-exporter/templates/deployment.yaml
+++ b/charts/modbus-exporter/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "modbus-exporter.fullname" . }}
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "modbus-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "modbus-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "modbus-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command: ["/bin/modbus_exporter"]
+          args:
+          - "--config.file=/etc/modbus_exporter/modbus.yml"
+          - "--log.level={{ .Values.log.level | default ("info") }}"
+          - "--log.format={{ .Values.log.format | default ("logfmt") }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9602
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9602
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: configfile
+            mountPath: /etc/modbus_exporter/
+            # mountPath: /app/modbus.yml
+            # subPath: modbus.yml
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: configfile
+        configMap:
+          {{- if not .Values.configMapFile }}
+          name: {{ include "modbus-exporter.fullname" . }}
+          {{- else }}
+          name: {{ .Values.configMapFile }}
+          {{- end }}

--- a/charts/modbus-exporter/templates/service.yaml
+++ b/charts/modbus-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "modbus-exporter.fullname" . }}
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 9602
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "modbus-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/modbus-exporter/templates/serviceaccount.yaml
+++ b/charts/modbus-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "modbus-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/modbus-exporter/templates/servicemonitor.yaml
+++ b/charts/modbus-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,52 @@
+{{- $fullName := include "modbus-exporter.fullname" . -}}
+{{- $endpointsCommonConfig := .Values.serviceMonitor.endpointsCommonConfig -}}
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "modbus-exporter.labels" . | nindent 6 }}
+  endpoints:
+  {{- range .Values.serviceMonitor.endpointsConfig }}
+  - port: metrics
+    path: "/modbus"
+{{ toYaml . | indent 4 }}
+    {{/*path: "/modbus&target=1.2.3.4:502" */}}
+    {{ toYaml $endpointsCommonConfig | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.serviceMonitorExporterItself.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullName }}-self-monitor
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitorExporterItself.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitorExporterItself.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "modbus-exporter.labels" . | nindent 6 }}
+  endpoints:
+  - port: metrics
+    path: "/metrics"
+{{- end }}

--- a/charts/modbus-exporter/templates/tests/test-connection.yaml
+++ b/charts/modbus-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+{{/*
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "modbus-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "modbus-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "modbus-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never
+*/}}

--- a/charts/modbus-exporter/values.yaml
+++ b/charts/modbus-exporter/values.yaml
@@ -1,0 +1,151 @@
+# Default values for modbus-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## if one needs to define the below modbus.yml in a separate configMap
+## that configMap name can be mentioned here:
+# configMapFile: "my-existing-modbus-config"
+
+## when the above configMapFile parameter is not defined, it will be created
+## using below parameters (usually send to the chart as custom values)
+modules:
+    # Module name, needs to be passed as parameter by Prometheus.
+    # the name must be matched with the name of serviceMonitor.endpointsConfig[x].params.module
+  - name: "fake"
+    protocol: 'tcp/ip'
+    metrics:
+        # Name of the metric.
+      - name: "power_consumption_total"
+        # Help text of the metric.
+        help: "represents the overall power consumption by phase"
+        # Labels to be added to the time series.
+        labels:
+          phase: "1"
+        # Register address.
+        # The first digit of the address is the function code
+        # Supported codes are: 1, 2, 3, 4
+        address: 300022
+        # Datatypes allowed: bool, int16, int32, int64, uint16, uint32, uint64,
+        #   float16, float32, float64
+        # One register holds 16 bits.
+        dataType: int16
+        # Endianness allowed: big, little, mixed, yolo
+        # Optional. If not defined: big.
+        endianness: big
+        # Prometheus metric type: https://prometheus.io/docs/concepts/metric_types/.
+        metricType: counter
+        # Factor can be specified to represent metric value.
+        # Examples: 1, 2, 1.543, 0.01 etc
+        # Factor is multiplied with the scraped value to produce the metric value
+        # Optional.
+        factor: 3.1415926535
+
+      - name: "some_gauge"
+        help: "some help for some gauge"
+        address: 30023
+        dataType: int16
+        metricType: gauge
+        factor: 2
+
+      - name: "coil"
+        help: "some help for some coil"
+        address: 124
+        dataType: bool
+        bitOffset: 0
+        metricType: gauge
+
+## The prometheus operator serviceMonitor for modbus
+serviceMonitor:
+  enabled: true
+  endpointsConfig:
+  -
+    params:
+      target:
+      - "10.1.2.3:502"
+      module:
+      ## module listed must be matched with the module[x].name specified in section above
+      - "fake"
+      sub_target:
+      - "1"
+  ## configurations common for all above endpoints:
+  endpointsCommonConfig:
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
+    scheme: http
+    interval: 10s
+    scrapeTimeout: 1s
+    metricRelabelings: []
+    relabelings: []
+    followRedirects: true
+    enableHttp2: false
+  annotations: {}
+  labels:
+    release: prometheus
+
+log:
+  ## choose one: debug,info,warn,error
+  level: "info"
+  ## logfmt,json
+  format: "logfmt"
+
+## The prometheus operator serviceMonitor for exporter itself
+serviceMonitorExporterItself:
+  enabled: true
+  annotations: {}
+  labels:
+    release: prometheus
+
+image:
+  registry: docker.io
+  # repository: richih/modbus_exporter
+  repository: openenergyprojects/modbus_exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9602
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Hi Richard,
thank you for the nice project, and thank you for actively maintaining it!

We are mainly in k8s, hence had to create a helm chart for your exporter.
Note that, for now, in the docs and default values I've set my repo, and once you automate the build of the image and build of the chart via github actions, the repo should be switched to yours.
I can advise further on the commands if required. E.g. 
```bash
helm package modbus-exporter/
helm push modbus-exporter-0.1.0.tgz oci://docker.io/openenergyprojects
```
Also, the version of the charts/modbus-exporter/Chart.yaml -> appVersion is set to "0.4.0", and it should be automatically incremented every version you release.

Also note that I had to build a new docker image, as the one you had in docker.io is very old, and the cli parameters did not match.

I have plans to add further improvements in the future (e.g. add an automatic configMap reload, so every time the configMap of modbus.yml is updated, to send SIGHUP (if you use that to reload config) or directly SIGKIL to the process. (if you support some special url to force config reload, let me know, I will use that instead of killing the process). As such, I plan to use: https://github.com/Pluies/config-reloader-sidecar for SIGHUP/KILL or , url reload: https://github.com/jimmidyson/configmap-reload )

The chart has been tested on our end, but, of course, please do a review from your end.
