### PR TITLE
Added ability to specify a directory of config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ usage: modbus_exporter [<flags>]
 Flags:
   -h, --[no-]help                Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --config.file="modbus.yml"  
+      --config.file=modbus.yml ...  
                                  Sets the configuration file.
       --[no-]web.systemd-socket  Use systemd socket activation listeners instead
                                  of port listeners (Linux only).
@@ -89,6 +89,8 @@ Visit http://localhost:9602/metrics to get the metrics of the exporter itself.
 Check out [`modbus.yml`](/modbus.yml) for more details on the configuration file
 format.
 
+The `--config.file` parameter can be used multiple times to load more than one file.
+It also supports [glob filename matching](https://pkg.go.dev/path/filepath#Glob), e.g. `modbus_*.yml`.
 
 ## TODO
 

--- a/modbus_exporter.go
+++ b/modbus_exporter.go
@@ -41,7 +41,7 @@ func main() {
 		configFile = kingpin.Flag(
 			"config.file",
 			"Sets the configuration file.",
-		).Default("modbus.yml").String()
+		).Default("modbus.yml").Strings()
 		toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9602")
 	)
 
@@ -59,7 +59,7 @@ func main() {
 	telemetryRegistry.MustRegister(collectors.NewGoCollector())
 	telemetryRegistry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
-	level.Info(logger).Log("msg", "Loading configuration file", "config_file", *configFile)
+	level.Info(logger).Log("msg", "Loading configuration file(s)", "config_file", strings.Join(*configFile, ", "))
 	config, err := config.LoadConfig(*configFile)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error loading config", "err", err)


### PR DESCRIPTION
After using this plugin for a little while, it started to become burdensome to navigate one huge configuration file for every metric of multiple modbus devices. I read through some issues and saw others mention this as well.

I decided to add basic functionality to specify either a single configuration file or a directory of configuration files in the format of [modbus.yml](https://github.com/omnistat/modbus_exporter/blob/main/modbus.yml). This will load all configurations as if they were in one file, but allows users to seperate them out for readability.

The folder name must end with `.d` to distinguish between a file or folder. For code simplicity, all files within the directory will attempt to be loaded, including non-yaml files, and error accordingly.

Example:
```python
modbus_configs.d
├── module1.yml
└── module2.yml

./modbus_exporter --config="modbus_configs.d"
```

Reflecting this change, the `--config.file` parameter has been changed to `--config` to be more general.