### PR TITLE
modbus_exporter: Handle race condition where the same endpoint is asked for different sub_targets too fast by Prometheus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,9 @@ type Module struct {
 }
 
 type Workarounds struct {
-	SleepAfterConnect time.Duration `yaml:"sleepAfterConnect"`
+	SleepAfterConnect     time.Duration `yaml:"sleepAfterConnect"`
+	ScrapeErrorRetryCount int           `yaml:"scrapeErrorRetryCount"` // Default value 3
+	ScrapeErrorWait       int           `yaml:"scrapeErrorWait"`       // In milliseconds, default value 100
 }
 
 // RegisterAddr specifies the register in the possible output of _digital

--- a/modbus.yml
+++ b/modbus.yml
@@ -4,9 +4,18 @@ modules:
   - name: "fake"
     protocol: 'tcp/ip'
     # Certain modbus devices need special timing workarounds
+    timeout: # int
+    baudrate: # int
+    databits: # int
+    stopbits: # int
+    parity: # string
     workarounds:
       # Sleep a certain time after the TCP connection is established
       sleepAfterConnect: "1s"
+      # Waiting period interval before trying to fulfill a failed scrape request again
+      scrapeErrorWait: # int representing milliseconds.
+      # Retries for failed scrape
+      scrapeErrorRetryCount: # int
     metrics:
         # Name of the metric.
       - name: "power_consumption_total"

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -29,7 +29,7 @@ import (
 // Exporter represents a Prometheus exporter converting modbus information
 // retrieved from remote targets via TCP as Prometheus style metrics.
 type Exporter struct {
-	config config.Config
+	Config config.Config
 }
 
 // NewExporter returns a new modbus exporter.
@@ -39,7 +39,7 @@ func NewExporter(config config.Config) *Exporter {
 
 // GetConfig loads the config file
 func (e *Exporter) GetConfig() *config.Config {
-	return &e.config
+	return &e.Config
 }
 
 // Scrape scrapes the given target via TCP based on the configuration of the
@@ -47,7 +47,7 @@ func (e *Exporter) GetConfig() *config.Config {
 func (e *Exporter) Scrape(targetAddress string, subTarget byte, moduleName string) (prometheus.Gatherer, error) {
 	reg := prometheus.NewRegistry()
 
-	module := e.config.GetModule(moduleName)
+	module := e.Config.GetModule(moduleName)
 	if module == nil {
 		return nil, fmt.Errorf("failed to find '%v' in config", moduleName)
 	}


### PR DESCRIPTION
Hi,

This patch fixes a race condition where Promtheus asks a modbus module too fast for a new query on the same target, but different sub-target. If a response have not been received by the time a new query has been sent out, the modbus_exporter receives the error `exception '11' (gateway target device failed to respond)` from the RS485 power meter, via the modbus gateway.

This adds an additional check if an error was received and then tries again if that is the case. This should not impact performance for healthy queries and responses as the result will be returned immediately. Two optional parameters `ScrapeErrorWait` and `ScrapeErrorRetryCount` have been added to configure the users module, and default setting if parameters is unset.

Additionally, if modbus exception 11 is received, a `HTTP 504 GateWayTimeOut` is now sent to Prometheus instead of `HTTP 500 InternalServerError`

This is my first time working with modbus and the Go language, so any points on improvements is very welcome.

## Background
A Prometheus alert was fired regarding a missing target, while working on unrelated targets on Prometheus. I encountered an error in Prometheus for a modbus target monitoring one of the power feeds at datacenter **site A**, `server returned HTTP status 500 Internal Server Error`, upon further investigation via the command `mbpoll -1 -0 -a 10 -t 3 -r 0 -v` it it showed that the target was still accessible (sub_target="10" is the failing target). However, the modbus_exporter returns the following error message: (tested with commit a144551d67136fc7c17eb8ad9146b3edb0f68821)

```
ts=2024-03-11T12:07:25.118Z caller=modbus_exporter.go:119 level=info msg="got scrape request" module=powermeter_peacefair_pzem_017 target=siteA.fiberby.net:502 sub_target=20
ts=2024-03-11T12:07:25.560Z caller=modbus_exporter.go:119 level=info msg="got scrape request" module=powermeter_peacefair_pzem_017 target=siteA.fiberby.net:502 sub_target=10
ts=2024-03-11T12:07:25.864Z caller=modbus_exporter.go:134 level=error msg="failed to scrape" target=siteA.fiberby.net:502 module=powermeter_peacefair_pzem_017 err="failed to scrape metrics for module 'powermeter_peacefair_pzem_017': metric 'power_voltage', address '400000': modbus: exception '11' (gateway target device failed to respond), function '132'"
ts=2024-03-11T12:07:25.873Z caller=modbus_exporter.go:119 level=info msg="got scrape request" module=powermeter_peacefair_pzem_017 target=siteA.fiberby.net:502 sub_target=20

... and so on

```

Notice how the `powermeter_peacefair_pzem_017` gets queried right after each other withing the same second. A closer look with TCPdump and Wireshark showed that a race condition happened where two sub-targets on the same target was queried while waiting for a response from a previous query on the same target. 

Curl'ing the sub-target directly, successfully returns the metrics:
```bash
curl 'localhost:10502/modbus?target=siteA.company.net:502&module=powermeter_peacefair_pzem_017&sub_target=10'
```

Results
```
# HELP power_consumption_total represents the overall power consumption by phase (kWh)
# TYPE power_consumption_total gauge
power_consumption_total{module="powermeter_peacefair_pzem_017"} 10689.811
# HELP power_current current drawn on phase
# TYPE power_current gauge
power_current{module="powermeter_peacefair_pzem_017"} 19.42
# HELP power_energy energy usage
# TYPE power_energy gauge
power_energy{module="powermeter_peacefair_pzem_017"} 1015.6
# HELP power_voltage voltage difference between neutral and phase
# TYPE power_voltage gauge
power_voltage{module="powermeter_peacefair_pzem_017"} 52.31
```

But if I query right after each other on the same module, but for sub-module 10 and 20. The result is that sub-target 10 returns a modbus 11 exception (gateway target device failed to respond)
```bash
for i in $(seq 1 10); do curl 'localhost:10502/modbus?target=siteA.company.net:502&module=powermeter_peacefair_pzem_017&sub_target=10'; curl 'localhost:10502/modbus?target=siteA.company.net:502&module=powermeter_peacefair_pzem_017&sub_target=20'; done
```
And as I can get the same error on other sites, with same power meter module. This seems to be a problem with the module itself.

Introducing a check if the scrape was succesful, and then wait 50 milliseconds eliminated this issue. 
I have only one type of power meter, but in my attempt to stress test the issue, a maximum of three retries was needed with 100 miliseconds sleep, in most cases only one retry

I am not happy with that an error log is being written every time the optional value is unset and and error is occurred, maybe it is fine, but I would like the option to be set per module and as a global config option but did not find a good solution to it.


```mermaid
---
title: Prometheus Modbus scrabing architecture
---
graph TD;
	A[(Prometheus)] -- TCP --- B[modbprobe_exporter];
	B -- ModBus TCP --- C[modbus gateway];
	C -- Modbus RTU (baud 9600 RS485) --- pm1["Power meter \n Peacefair PZEM-003/017"]
	pm1 -- RS485 --- pfA["Power feed A\n subtarget 10"]
	pfA -- RS485 --- pfB["Power feed B\n subtarget 20"]
```
