### PR TITLE
Accept target and sub_target in module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,17 @@ Flags:
       --[no-]version             Show application version.
 
 ```
-Visit http://localhost:9602/modbus?target=1.2.3.4:502&module=fake&sub_target=1 where 1.2.3.4:502 is the IP and port number of the modbus IP device to get metrics from,
-while module and sub_target parameters specify which module and subtarget to use from the config file.
+Visit http://localhost:9602/modbus?module=fake&target=1.2.3.4:502&sub_target=1 where:
+
+- the `module` parameter specifies which module to use from the config file;
+- the `target` parameter specifies the IP and port number of the modbus IP device to get metrics from, e.g. `1.2.3.4:502`;
+- the `sub_target` specifies the slave address/id to use in the modbus request;
+
 If your device doesn't use sub-targets you can usually just set it to 1.
+
+Note `target` and `sub_target` may be provided per-module in the config,
+in which case the respective value in the request is ignored.
+This is useful e.g. if you only have one device per module and don't want to accept the IP address in the request.
 
 Visit http://localhost:9602/metrics to get the metrics of the exporter itself.
 

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,8 @@ type ListTargets map[string]*Module
 type Module struct {
 	Name        string         `yaml:"name"`
 	Protocol    ModbusProtocol `yaml:"protocol"`
+	Target      *string        `yaml:"target"`
+	SubTarget   *uint8         `yaml:"subTarget"`
 	Timeout     int            `yaml:"timeout"`
 	Baudrate    int            `yaml:"baudrate"`
 	Databits    int            `yaml:"databits"`

--- a/modbus.yml
+++ b/modbus.yml
@@ -3,6 +3,15 @@ modules:
     # Module name, needs to be passed as parameter by Prometheus.
   - name: "fake"
     protocol: 'tcp/ip'
+
+    # IP and port number of the modbus IP device to get metrics from.
+    # Optinal. If specified, this value is used and the target HTTP request parameter is ignored.
+    # target: "1.2.3.4:502"
+
+    # Modbus slave address/id to use
+    # Optional. If specified, this value is used and the sub_target HTTP request parameter is ignored.
+    # subTarget: 0
+
     # Certain modbus devices need special timing workarounds
     workarounds:
       # Sleep a certain time after the TCP connection is established


### PR DESCRIPTION
Allows `target` and `sub_target` to be specified per-module in the config file, respectively as `target` and `subTarget`.

If specified in the config, the respective parameter is ignored in the HTTP request.

This is useful e.g. if you only have one device per module and don't want to accept the IP address in the request.