### PR TITLE
Allow to read coils with bitOffset higher than 7

### DIFF
--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -272,7 +272,7 @@ func parseModbusData(d config.MetricDef, rawData []byte) (float64, error) {
 			}
 
 			// Convert byte to uint16
-			data := uint16(rawData[0])
+			data := binary.BigEndian.Uint16(rawData)
 
 			if data&(uint16(1)<<uint16(*d.BitOffset)) > 0 {
 				return float64(1), nil


### PR DESCRIPTION
When reading 16-bit register as an array of coils the upper 8 bits are being ignored resulting to the wrong coil values read. This change fixes this.