### PR TITLE
Auto-detect and handle continues range of metrics in a module.

### DIFF
--- a/modbus.yml
+++ b/modbus.yml
@@ -2,6 +2,8 @@ modules:
 
     # Module name, needs to be passed as parameter by Prometheus.
   - name: "fake"
+    useRanges: true
+    rangeSensitivity: 10
     protocol: 'tcp/ip'
     # Certain modbus devices need special timing workarounds
     timeout: # int

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -17,14 +17,41 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/RichiH/modbus_exporter/config"
 	"github.com/goburrow/modbus"
+	"sort"
 )
+
+const (
+	rangeDefaultSensitivity uint64 = 10
+	useRangeDefault                = true
+)
+
+func getUseRange(m config.Module, c config.Config) bool {
+	r := useRangeDefault
+	if c.UseRanges != nil {
+		r = *c.UseRanges
+	}
+	if m.UseRanges != nil {
+		r = *m.UseRanges
+	}
+	return r
+}
+
+func getRangeSensibility(m config.Module, c config.Config) uint64 {
+	s := rangeDefaultSensitivity
+	if c.RangeSensitivity != 0 {
+		s = c.RangeSensitivity
+	}
+	if m.RangeSensitivity != 0 {
+		s = m.RangeSensitivity
+	}
+	return s
+}
 
 // Exporter represents a Prometheus exporter converting modbus information
 // retrieved from remote targets via TCP as Prometheus style metrics.
@@ -72,16 +99,13 @@ func (e *Exporter) Scrape(targetAddress string, subTarget byte, moduleName strin
 
 	// Close tcp connection.
 	defer handler.Close()
-
-	metrics, err := scrapeMetrics(module.Metrics, c)
+	metrics, err := scrapeMetrics(module.Metrics, c, *module, e.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scrape metrics for module '%v': %v", moduleName, err.Error())
 	}
-
 	if err := registerMetrics(reg, moduleName, metrics); err != nil {
 		return nil, fmt.Errorf("failed to register metrics for module %v: %v", moduleName, err.Error())
 	}
-
 	return reg, nil
 }
 
@@ -169,58 +193,149 @@ func keys(m map[string]string) []string {
 	return keys
 }
 
-func scrapeMetrics(definitions []config.MetricDef, c modbus.Client) ([]metric, error) {
+func generateRangeMap(definitions []config.MetricDef, c modbus.Client, sensitivity uint64) (rangeMap RangeMap, err error) {
+	//init rangeMap
+	rangeMap = initializeRangeMap(c)
+
+	//sort slice based on modAddress
+	sort.Slice(definitions, func(i, j int) bool {
+		iAddress, _ := definitions[i].Address.GetModAddress()
+		jAddress, _ := definitions[j].Address.GetModAddress()
+		return iAddress < jAddress
+	})
+
+	for _, definition := range definitions {
+		modFunction, err := definition.Address.GetModFunction()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		r, err := validateModFunction(rangeMap, modFunction)
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		//if range definitions contain no interval add an empty interval
+		if len(r.definitions) == 0 {
+			r.definitions = append(r.definitions, []config.MetricDef{})
+		}
+		lastDefInterval := r.definitions[len(r.definitions)-1]
+		//if last interval have no content add definition to it and skip
+		if len(lastDefInterval) == 0 {
+			lastDefInterval = append(lastDefInterval, definition)
+			r.definitions[len(r.definitions)-1] = lastDefInterval
+			rangeMap[modFunction] = r
+			continue
+		}
+		firstDef := lastDefInterval[0]
+		lastDef := lastDefInterval[len(lastDefInterval)-1]
+		firstDefAddress, err := firstDef.Address.GetModAddress()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		lastDefAddress, err := lastDef.Address.GetModAddress()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		modAddress, err := definition.Address.GetModAddress()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		//calculate current total offset for the current open interval
+		//if offset is more than 2000 can't be handled only in 1 request so a new interval is opened
+		totalRangeOffset := uint16(modAddress-firstDefAddress) + definition.DataType.Offset()
+		if modAddress-lastDefAddress > sensitivity || totalRangeOffset > 2000 {
+			r.definitions = append(r.definitions, []config.MetricDef{})
+		}
+		//add definition to last open interval
+		r.definitions[len(r.definitions)-1] = append(r.definitions[len(r.definitions)-1], definition)
+		rangeMap[modFunction] = r
+	}
+	return rangeMap, nil
+}
+
+// Initializes the RangeMap with predefined Modbus functions
+func initializeRangeMap(c modbus.Client) RangeMap {
+	return RangeMap{
+		1: {F: c.ReadCoils},
+		2: {F: c.ReadDiscreteInputs},
+		3: {F: c.ReadHoldingRegisters},
+		4: {F: c.ReadInputRegisters},
+	}
+}
+
+// Validates if the modFunction exists in the rangeMap and returns the Range object
+func validateModFunction(rangeMap RangeMap, modFunction uint64) (Range, error) {
+	rangeObj, ok := rangeMap[modFunction]
+	if !ok {
+		return Range{}, fmt.Errorf("invalid modFunction: %v", modFunction)
+	}
+	return rangeObj, nil
+}
+
+func scrapeMetrics(definitions []config.MetricDef, c modbus.Client, m config.Module, conf config.Config) ([]metric, error) {
 	metrics := []metric{}
 
 	if len(definitions) == 0 {
 		return []metric{}, nil
 	}
+	if !getUseRange(m, conf) {
+		for _, definition := range definitions {
+			var f modbusFunc
 
-	for _, definition := range definitions {
-		var f modbusFunc
+			// Here we are parcing Modbus Address from config file
+			// for function code and register address
+			modFunction, err := definition.Address.GetModFunction()
+			if err != nil {
+				return []metric{}, fmt.Errorf("modbus function code parcing failed: %v", modFunction)
+			}
 
-		// Here we are parcing Modbus Address from config file
-		// for function code and register address
-		modFunction, err := strconv.ParseUint(fmt.Sprint(definition.Address)[0:1], 10, 64)
+			// And here we are parcing Modbus Address from config file
+			// for register address
+			modAddress, err := definition.Address.GetModAddress()
+			if err != nil {
+				return []metric{}, fmt.Errorf("modbus register address parcing failed  %v", modAddress)
+			}
+
+			if modAddress > 65535 {
+				return []metric{}, fmt.Errorf("modbus register address is out of range: %v", definition.Address)
+			}
+
+			switch modFunction {
+			case 1:
+				f = c.ReadCoils
+			case 2:
+				f = c.ReadDiscreteInputs
+			case 3:
+				f = c.ReadHoldingRegisters
+			case 4:
+				f = c.ReadInputRegisters
+			default:
+				return []metric{}, fmt.Errorf(
+					"metric: '%v', address '%v': metric address should be within the range of 10 - 465535."+
+						"'1xxxxx' for read coil / digital output, '2xxxxx' for read discrete inputs / digital input,"+
+						"'3xxxxx' read holding registers / analog output, '4xxxxx' read input registers / analog input",
+					definition.Name, definition.Address,
+				)
+			}
+
+			m, err := scrapeMetric(definition, f, modAddress)
+			if err != nil {
+				return []metric{}, fmt.Errorf("metric '%v', address '%v': %v", definition.Name, definition.Address, err)
+			}
+
+			metrics = append(metrics, m)
+		}
+	} else {
+		rangeMap, err := generateRangeMap(definitions, c, getRangeSensibility(m, conf))
 		if err != nil {
-			return []metric{}, fmt.Errorf("modbus function code parcing failed: %v", modFunction)
+			return nil, err
 		}
-
-		// And here we are parcing Modbus Address from config file
-		// for register address
-		modAddress, err := strconv.ParseUint(fmt.Sprint(definition.Address)[1:], 10, 64)
-		if err != nil {
-			return []metric{}, fmt.Errorf("modbus register address parcing failed  %v", modAddress)
+		for _, r := range rangeMap {
+			m, err := scrapeMetricRange(r)
+			if err != nil {
+				return nil, err
+			}
+			metrics = append(metrics, m...)
 		}
-
-		if modAddress > 65535 {
-			return []metric{}, fmt.Errorf("modbus register address is out of range: %v", definition.Address)
-		}
-
-		switch modFunction {
-		case 1:
-			f = c.ReadCoils
-		case 2:
-			f = c.ReadDiscreteInputs
-		case 3:
-			f = c.ReadHoldingRegisters
-		case 4:
-			f = c.ReadInputRegisters
-		default:
-			return []metric{}, fmt.Errorf(
-				"metric: '%v', address '%v': metric address should be within the range of 10 - 465535."+
-					"'1xxxxx' for read coil / digital output, '2xxxxx' for read discrete inputs / digital input,"+
-					"'3xxxxx' read holding registers / analog output, '4xxxxx' read input registers / analog input",
-				definition.Name, definition.Address,
-			)
-		}
-
-		m, err := scrapeMetric(definition, f, modAddress)
-		if err != nil {
-			return []metric{}, fmt.Errorf("metric '%v', address '%v': %v", definition.Name, definition.Address, err)
-		}
-
-		metrics = append(metrics, m)
 	}
 
 	return metrics, nil
@@ -236,19 +351,7 @@ func scrapeMetric(definition config.MetricDef, f modbusFunc, modAddress uint64) 
 	// For future reference, the maximum for digital in/output is 2000 registers,
 	// the maximum for analog in/output is 125.
 	var div uint16
-	switch definition.DataType {
-	case config.ModbusFloat16,
-		config.ModbusInt16,
-		config.ModbusBool,
-		config.ModbusUInt16:
-		div = uint16(1)
-	case config.ModbusFloat32,
-		config.ModbusInt32,
-		config.ModbusUInt32:
-		div = uint16(2)
-	default:
-		div = uint16(4)
-	}
+	div = definition.DataType.Offset()
 
 	// TODO: We could cache the results to not repeat overlapping ones.
 
@@ -263,6 +366,52 @@ func scrapeMetric(definition config.MetricDef, f modbusFunc, modAddress uint64) 
 	}
 
 	return metric{definition.Name, definition.Help, definition.Labels, v, definition.MetricType}, nil
+}
+
+// scrapeMetricRange retrieves and parses Modbus register data for a given range and returns metrics or an error.
+// It computes offsets, fetches register bytes using a Modbus function, and converts data using metric definitions.
+// It auto handle "dirty" registry and parse only interested data.
+func scrapeMetricRange(r Range) ([]metric, error) {
+	var metrics []metric
+
+	for _, definitions := range r.definitions {
+		first := definitions[0]
+		last := definitions[len(definitions)-1]
+		firstAddress, err := first.Address.GetModAddress()
+		if err != nil {
+			return nil, fmt.Errorf("can't calculate mod address for %s: %v", first.Name, err)
+		}
+		lastAddress, err := last.Address.GetModAddress()
+		if err != nil {
+			return nil, fmt.Errorf("can't calculate mod address for %s: %v", last.Name, err)
+		}
+		lastOffset := last.DataType.Offset()
+		totalOffset := uint16(lastAddress-firstAddress) + lastOffset
+
+		//get all bytes from the first registry to the last
+		modBytes, err := r.F(uint16(firstAddress), totalOffset)
+		if err != nil {
+			return nil, fmt.Errorf("can't read modbus registers for %s: %v", first.Name, err)
+		}
+
+		//for each definition extract interested bytes and parse to a metric
+		for _, definition := range definitions {
+			modAddress, err := definition.Address.GetModAddress()
+			if err != nil {
+				return nil, fmt.Errorf("can't calculate mod address for %s: %v", definition.Name, err)
+			}
+			start := (modAddress - firstAddress) * 2
+			end := uint16(start) + (definition.DataType.Offset() * 2)
+			defBytes := modBytes[start:end]
+			v, err := parseModbusData(definition, defBytes)
+			if err != nil {
+				return nil, fmt.Errorf("can't parse modbus data for %s: %v", definition.Name, err)
+			}
+			metrics = append(metrics, metric{definition.Name, definition.Help, definition.Labels, v, definition.MetricType})
+		}
+	}
+
+	return metrics, nil
 }
 
 // InsufficientRegistersError is returned in Parse() whenever not enough

--- a/modbus/range.go
+++ b/modbus/range.go
@@ -1,0 +1,13 @@
+package modbus
+
+import "github.com/RichiH/modbus_exporter/config"
+
+// Range defines a Modbus range that includes a Modbus function and associated metric definitions.
+// metric definitions is a slice of continuous or semi-continuous(based on sensitivity) definition interval.
+type Range struct {
+	F           modbusFunc
+	definitions [][]config.MetricDef
+}
+
+// RangeMap represents a mapping of Modbus function codes to corresponding Range objects.
+type RangeMap map[uint64]Range


### PR DESCRIPTION
The exporter now before scraping register of Slave server sort all module metrics splitting their in multiple continues intervals based on rangeSensitivity. Next execute only one request for fetch all data's and split it in Metric objects directly in memory.

Benchmark on 20 metrics:

Pre-commit: 7.280s

After-commit: 0.641s

![modbus_exporter_comparision](https://github.com/user-attachments/assets/df9c6125-2843-4d3f-94c2-b960b98ba5a0)


Is also possible to disable range and set range sentitivity settings:

`useRanges: false`
`rangeSensitivity: 10`

In root config or in Module.
